### PR TITLE
fix: reset API version to wip on main (fixes #39)

### DIFF
--- a/code/API_definitions/most-frequent-location.yaml
+++ b/code/API_definitions/most-frequent-location.yaml
@@ -75,13 +75,13 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.2.0
+  version: wip
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/MostFrequentLocation
 servers:
-  - url: "{apiRoot}/most-frequent-location/v0.2"
+  - url: "{apiRoot}/most-frequent-location/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/most-frequent-location.feature
+++ b/code/Test_definitions/most-frequent-location.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Most Frequent Location API, v0.2.0
+Feature: CAMARA Most Frequent Location API, vwip
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -14,7 +14,7 @@ Feature: CAMARA Most Frequent Location API, v0.2.0
 
   Background: Common verifyFrequentLocation setup
     Given an environment at "apiRoot"
-    And the resource "/most-frequent-location/v0.2/verify"
+    And the resource "/most-frequent-location/vwip/verify"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Resets API version information on `main` to `wip` after the previous release, per the standard CAMARA post-release procedure.

This is a mandatory prerequisite for the Release Automation roll-out: the framework requires `wip` / `vwip` versions on `main` so the release process can drive transitions to concrete versions on dedicated release branches.

Two files updated, four lines:

- `code/API_definitions/most-frequent-location.yaml`: `info.version` `0.2.0` → `wip`; server URL `v0.2` → `vwip`
- `code/Test_definitions/most-frequent-location.feature`: line 1 Feature header `v0.2.0` → `vwip`; line 17 resource URL `v0.2` → `vwip`

#### Which issue(s) this PR fixes:

Fixes #39

#### Special notes for reviewers:

Mechanical wip reset. No semantic changes.

#### Changelog input

```
 release-note
Reset API version on main to wip (post-release procedure).
```

#### Additional documentation

This section can be blank.

```
docs

```
